### PR TITLE
Filter by ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This project runs completely in the browser. It expects a few parameters in the 
 - **gitlab**: your gitlab server address
 - **token**: your gitlab token
 - **projects**: a list of projects you want to monitor, separated with commas
+- **ref** (optional): show the last build of a specific ref (like **master**)
 
 Example:
 
 ```
-http://gitlab-ci-monitor.example.com/?gitlab=gitlab.example.com&token=12345&projects=project1,project2,project3
+http://gitlab-ci-monitor.example.com/?gitlab=gitlab.example.com&token=12345&projects=project1,project2,project3&ref=master
 ```
 
-With these parameters, it will try to fetch the list of projects that this token has access. Then, it will filter the list by the **projects** parameter, and show only the ones that have builds (i.e., that have GitLab CI enabled). Finally, it will show the status from the most recent build.
+With these parameters, it will try to fetch the list of projects that this token has access. Then, it will filter the list by the **projects** parameter, and show only the ones that have builds (i.e., that have GitLab CI enabled). Finally, it will show the status from the most recent build in **master** branch.

--- a/js/app.js
+++ b/js/app.js
@@ -46,6 +46,7 @@ var app = new Vue({
       this.gitlab = getParameterByName("gitlab")
       this.token = getParameterByName("token")
       repositories = getParameterByName("projects")
+      this.ref = getParameterByName("ref")
       if (repositories == null) {
         return
       }
@@ -86,7 +87,10 @@ var app = new Vue({
           .then(function (response) {
             updated = false
 
-            build = response.data[0]
+            build = self.filterLastBuild(response.data)
+            if (!build) {
+              return
+            }
             startedFromNow = moment(build.started_at).fromNow()
 
             self.builds.forEach(function(b){
@@ -114,6 +118,21 @@ var app = new Vue({
           })
           .catch(onError.bind(self));
       })
+    },
+
+    filterLastBuild: function(builds) {
+      if (!Array.isArray(builds) || builds.length === 0) {
+        return
+      }
+
+      if (this.ref) {
+        var self = this
+        return builds.find(function(build) {
+          return build.ref === self.ref
+        })
+      } else {
+        return builds[0]
+      }
     }
   }
 })

--- a/js/app.js
+++ b/js/app.js
@@ -68,7 +68,7 @@ var app = new Vue({
     fetchProjecs: function() {
       var self = this
       self.loading = true
-      axios.get('/projects?per_page=100')
+      axios.get('/projects?per_page=100&simple=true')
         .then(function (response) {
           self.loading = false
           self.projects = response.data.filter(function(p){
@@ -117,5 +117,3 @@ var app = new Vue({
     }
   }
 })
-
-


### PR DESCRIPTION
Add support to filter builds by a specific ref. Also, add `simple=true` parameter to requests to GitLab API, making it much faster