### PR TITLE
Add options to sort projects by name and status 

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,13 @@
               <img class="logo" src="images/gitlab-logo.svg"/>
             </div>
             <div class="six wide column">
+              <div class="ui buttons right floated">
+                <a v-for="sort in availableSorts" v-on:click="changeOrder(sort.field)"
+                  v-bind:class="{active: isSortedBy(sort.field), ui: true, button: true}"
+                  v-bind:title="sort.text">
+                  <i v-bind:class="[sort.icon, (reverseOrder && isSortedBy(sort.field) ? 'descending' : 'ascending'), 'sort', 'icon']"></i>
+                </a>
+              </div>
             </div>
           </div>
         </div>
@@ -63,7 +70,7 @@
       <div class="row builds">
         <div class="sixteen wide column">
           <div class="ui stackable cards">
-            <div v-for="pipeline in pipelines" class="card {{pipeline.status}}">
+            <div v-for="pipeline in sortedPipelines" class="card {{pipeline.status}}">
               <div class="content">
                 <div class="header project-name">
                   <a target="_blank" title="overview of {{pipeline.project}}" href="https://{{gitlab}}/{{pipeline.project_path}}/">{{ pipeline.project }}</a> <a target="_blank" title="file tree branch {{pipeline.branch}} of {{pipeline.project}}" href="https://{{gitlab}}/{{pipeline.project_path}}/tree/{{pipeline.branch}}">({{ pipeline.branch }})</a>

--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,21 @@ const app = new Vue({
     loading: false,
     invalidConfig: false,
     lastRun: lastRun(),
-    onError: null
+    onError: null,
+    sortField: "project",
+    reverseOrder: false,
+    availableSorts: [
+      {
+        field: "project",
+        icon: "alphabet",
+        text: "Order by project name"
+      },
+      {
+        field: "status",
+        icon: "content",
+        text: "Order by status"
+      }
+    ]
   },
   created: function() {
     this.loadConfig()
@@ -175,7 +189,14 @@ const app = new Vue({
       self.onError = null
       Object.values(self.projects).forEach(function(p) { self.fetchBuild(p) })
       self.lastRun = lastRun()
-      self.pipelines.sort(function(a, b) { return a.project.localeCompare(b.project) })
+    },
+    changeOrder: function(field){
+      if (this.sortField == field)
+        this.reverseOrder = !this.reverseOrder
+      else {
+        this.sortField = field
+        this.reverseOrder = false
+      }
     },
     fetchBuild: function(p) {
       const self = this
@@ -228,6 +249,18 @@ const app = new Vue({
           }
         })
         .catch(onError.bind(self))
+    },
+    isSortedBy: function(field){
+      return field == this.sortField
     }
-  }
+  },
+  computed: {
+    sortedPipelines: function() {
+      var self = this;
+      return self.pipelines.sort(function(a,b){
+        var comparison = a[self.sortField].localeCompare(b[self.sortField])
+        return self.reverseOrder ? -comparison : comparison
+      })
+    }
+  },
 })


### PR DESCRIPTION
Add options to sort projects by name and status.
This is a sample with the new options:
![order](https://user-images.githubusercontent.com/411799/46845546-3f058800-cdb2-11e8-8fbf-111df34cf646.gif)

Closes #18 