### PR TITLE
Possibility to add projects of subgroups

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -146,6 +146,7 @@ const app = new Vue({
       const self = this
       self.groups.forEach(function(g) {
         self.loading = true
+        g = encodeURIComponent(g);
         axios.get('/groups/' + g)
           .then(function (response) {
             self.loading = false


### PR DESCRIPTION
New versions of Gitlab allows groups have subgroups. This project
was not handling subgroups correctly.
With this modification subgroups can be passed on "group" querystring
parameter and it will add all its projects.