### PR TITLE
Update NPM dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -772,187 +772,191 @@
       }
     },
     "@webassemblyjs/ast": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.8.tgz",
-      "integrity": "sha512-dOrtdtEyB8sInpl75yLPNksY4sRl0j/+t6aHyB/YA+ab9hV3Fo7FmG12FHzP+2MvWVAJtDb+6eXR5EZbZJ+uVg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/wast-parser": "1.7.8"
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.8.tgz",
-      "integrity": "sha512-kn2zNKGsbql5i56VAgRYkpG+VazqHhQQZQycT2uXAazrAEDs23gy+Odkh5VblybjnwX2/BITkDtNmSO76hdIvQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.8.tgz",
-      "integrity": "sha512-xUwxDXsd1dUKArJEP5wWM5zxgCSwZApSOJyP1XO7M8rNUChUDblcLQ4FpzTpWG2YeylMwMl1MlP5Ztryiz1x4g==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.8.tgz",
-      "integrity": "sha512-WXiIMnuvuwlhWvVOm8xEXU9DnHaa3AgAU0ZPfvY8vO1cSsmYb2WbGbHnMLgs43vXnA7XAob9b56zuZaMkxpCBg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.8.tgz",
-      "integrity": "sha512-TLQxyD9qGOIdX5LPQOPo0Ernd88U5rHkFb8WAjeMIeA0sPjCHeVPaGqUGGIXjUcblUkjuDAc07bruCcNHUrHDA==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.7.8"
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.8.tgz",
-      "integrity": "sha512-TjK0CnD8hAPkV5mbSp5aWl6SO1+H3WFcjWtixWoy8EMA99YnNzYhpc/WSYWhf7yrhpzkq5tZB0tvLK3Svr3IXA==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.8.tgz",
-      "integrity": "sha512-uCutAKR7Nm0VsFixcvnB4HhAyHouNbj0Dx1p7eRjFjXGGZ+N7ftTaG1ZbWCasAEbtwGj54LP8+lkBZdTCPmLGg==",
-      "dev": true
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "^0.0.3"
+      }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.8.tgz",
-      "integrity": "sha512-AdCCE3BMW6V34WYaKUmPgVHa88t2Z14P4/0LjLwuGkI0X6pf7nzp0CehzVVk51cKm2ymVXjl9dCG+gR1yhITIQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.8.tgz",
-      "integrity": "sha512-BkBhYQuzyl4hgTGOKo87Vdw6f9nj8HhI7WYpI0MCC5qFa5ahrAPOGgyETVdnRbv+Rjukl9MxxfDmVcVC435lDg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.8.tgz",
-      "integrity": "sha512-tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.8.tgz",
-      "integrity": "sha512-GCYeGPgUFWJiZuP4NICbcyUQNxNLJIf476Ei+K+jVuuebtLpfvwkvYT6iTUE7oZYehhkor4Zz2g7SJ/iZaPudQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
       "dev": true,
       "requires": {
-        "@xtuc/long": "4.2.1"
+        "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.8.tgz",
-      "integrity": "sha512-9X+f0VV+xNXW2ujfIRSXBJENGE6Qh7bNVKqu3yDjTFB3ar3nsThsGBBKdTG58aXOm2iUH6v28VIf88ymPXODHA==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.8.tgz",
-      "integrity": "sha512-6D3Hm2gFixrfyx9XjSON4ml1FZTugqpkIz5Awvrou8fnpyprVzcm4X8pyGRtA2Piixjl3DqmX/HB1xdWyE097A==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/helper-wasm-section": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8",
-        "@webassemblyjs/wasm-opt": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8",
-        "@webassemblyjs/wast-printer": "1.7.8"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.8.tgz",
-      "integrity": "sha512-a7O/wE6eBeVKKUYgpMK7NOHmMADD85rSXLe3CqrWRDwWff5y3cSVbzpN6Qv3z6C4hdkpq9qyij1Ga1kemOZGvQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/ieee754": "1.7.8",
-        "@webassemblyjs/leb128": "1.7.8",
-        "@webassemblyjs/utf8": "1.7.8"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.8.tgz",
-      "integrity": "sha512-3lbQ0PT81NHCdi1sR/7+SNpZadM4qYcTSr62nFFAA7e5lFwJr14M1Gi+A/Y3PgcDWOHYjsaNGPpPU0H03N6Blg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-buffer": "1.7.8",
-        "@webassemblyjs/wasm-gen": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.8.tgz",
-      "integrity": "sha512-rZ/zlhp9DHR/05zh1MbAjT2t624sjrPP/OkJCjXqzm7ynH+nIdNcn9Ixc+qzPMFXhIrk0rBoQ3to6sEIvHh9jQ==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-api-error": "1.7.8",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.8",
-        "@webassemblyjs/ieee754": "1.7.8",
-        "@webassemblyjs/leb128": "1.7.8",
-        "@webassemblyjs/utf8": "1.7.8"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.8.tgz",
-      "integrity": "sha512-Q/zrvtUvzWuSiJMcSp90fi6gp2nraiHXjTV2VgAluVdVapM4gy1MQn7akja2p6eSBDQpKJPJ6P4TxRkghRS5dg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/floating-point-hex-parser": "1.7.8",
-        "@webassemblyjs/helper-api-error": "1.7.8",
-        "@webassemblyjs/helper-code-frame": "1.7.8",
-        "@webassemblyjs/helper-fsm": "1.7.8",
-        "@xtuc/long": "4.2.1"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
+        "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.8.tgz",
-      "integrity": "sha512-GllIthRtwTxRDAURRNXscu7Napzmdf1jt1gpiZiK/QN4fH0lSGs3OTmvdfsMNP7tqI4B3ZtfaaWRlNIQug6Xyg==",
+      "version": "1.8.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/wast-parser": "1.7.8",
-        "@xtuc/long": "4.2.1"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
+        "@xtuc/long": "4.2.2"
       }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-      "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+      "version": "4.2.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
     "abab": {
@@ -975,15 +979,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-    },
-    "acorn-dynamic-import": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.0"
-      }
     },
     "acorn-globals": {
       "version": "4.3.0",
@@ -1182,8 +1177,8 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -1192,11 +1187,12 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -1247,9 +1243,9 @@
       "dev": true
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "version": "1.0.3",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "async-limiter": {
@@ -1283,12 +1279,40 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "axios-mock-adapter": {
@@ -1718,9 +1742,9 @@
       "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "version": "1.3.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
       "dev": true
     },
     "batch": {
@@ -1745,10 +1769,20 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+      "version": "1.13.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.5.2",
@@ -1758,8 +1792,8 @@
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
@@ -1895,8 +1929,8 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -1909,8 +1943,8 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
@@ -1920,8 +1954,8 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1957,8 +1991,8 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -1985,9 +2019,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -2139,24 +2173,31 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.8",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "dev": true
+        }
       }
     },
     "chownr": {
@@ -2166,9 +2207,9 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "version": "1.0.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2182,8 +2223,8 @@
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -2420,13 +2461,10 @@
       "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "^0.1.4"
-      }
+      "version": "1.2.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2551,8 +2589,8 @@
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -2561,8 +2599,8 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
@@ -2574,8 +2612,8 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
@@ -2601,8 +2639,8 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -2766,12 +2804,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
     },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
-    },
     "debug": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
@@ -2910,9 +2942,9 @@
       "dev": true
     },
     "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "version": "1.0.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -2963,8 +2995,8 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -3045,8 +3077,8 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "domelementtype": {
@@ -3118,9 +3150,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/elliptic/-/elliptic-6.5.2.tgz",
+      "integrity": "sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -3318,10 +3350,21 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.3",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+          "dev": true
+        }
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3388,9 +3431,9 @@
       "dev": true
     },
     "events": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "version": "3.1.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/events/-/events-3.1.0.tgz",
+      "integrity": "sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=",
       "dev": true
     },
     "eventsource": {
@@ -3404,8 +3447,8 @@
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -3769,6 +3812,12 @@
         "bser": "^2.0.0"
       }
     },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
+      "dev": true
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3810,6 +3859,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -3928,6 +3984,7 @@
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
       "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -3936,6 +3993,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3943,7 +4001,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4035,14 +4094,15 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.11",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha1-Z79X9HWPAu3oj7KhcS/vTRU1i+M=",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1",
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -4054,7 +4114,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4063,7 +4124,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4089,7 +4150,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4119,16 +4180,16 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4146,12 +4207,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -4177,7 +4238,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4197,16 +4258,16 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4225,7 +4286,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4267,22 +4328,22 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -4295,38 +4356,38 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -4340,13 +4401,22 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4417,18 +4487,18 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -4458,18 +4528,19 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4484,7 +4555,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4525,6 +4596,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4536,18 +4608,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -4557,23 +4629,25 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4731,49 +4805,22 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.7.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha1-ARJ7OEAVagknBYd5SCAxr+DnMNc=",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        },
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true,
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.17.1",
-            "source-map": "~0.6.1"
-          }
         }
       }
     },
@@ -4900,9 +4947,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -5172,9 +5219,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "version": "1.1.13",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "iferr": {
@@ -5259,10 +5306,10 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
@@ -5387,7 +5434,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -5828,17 +5876,6 @@
             "repeat-element": "^1.1.2"
           }
         },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -5846,18 +5883,29 @@
           "dev": true
         },
         "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "version": "1.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            }
           }
         },
         "expand-brackets": {
@@ -5887,12 +5935,6 @@
             "pkg-dir": "^2.0.0",
             "resolve-cwd": "^2.0.0"
           }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
@@ -5962,24 +6004,6 @@
             "is-buffer": "^1.1.5"
           }
         },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
         "micromatch": {
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -6002,14 +6026,24 @@
           }
         },
         "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "version": "3.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "slash": {
@@ -6025,16 +6059,16 @@
           "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "version": "11.1.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/yargs/-/yargs-11.1.1.tgz",
+          "integrity": "sha1-UFLv40RqTfXtZpyZWIbMDxNwJ2Y=",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -6694,17 +6728,6 @@
             "repeat-element": "^1.1.2"
           }
         },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6721,18 +6744,29 @@
           "dev": true
         },
         "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "version": "1.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            }
           }
         },
         "expand-brackets": {
@@ -6752,12 +6786,6 @@
           "requires": {
             "is-extglob": "^1.0.0"
           }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
@@ -6781,24 +6809,6 @@
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
           }
         },
         "micromatch": {
@@ -6829,14 +6839,24 @@
           "dev": true
         },
         "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "version": "3.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "slash": {
@@ -6858,16 +6878,16 @@
           "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "version": "11.1.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/yargs/-/yargs-11.1.1.tgz",
+          "integrity": "sha1-UFLv40RqTfXtZpyZWIbMDxNwJ2Y=",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
             "decamelize": "^1.1.1",
             "find-up": "^2.1.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
@@ -6993,9 +7013,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -7050,8 +7070,8 @@
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
@@ -7197,9 +7217,9 @@
       }
     },
     "loader-runner": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-      "integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==",
+      "version": "2.4.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
     "loader-utils": {
@@ -7224,21 +7244,15 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.sortby": {
@@ -7304,6 +7318,12 @@
         "tmpl": "1.0.x"
       }
     },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
@@ -7336,8 +7356,8 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -7422,8 +7442,8 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -7525,9 +7545,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -7536,8 +7556,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -7596,9 +7616,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "dev": true,
       "optional": true
     },
@@ -7634,9 +7654,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
-      "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
+      "version": "2.6.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
     "nice-try": {
@@ -7667,9 +7687,9 @@
       "dev": true
     },
     "node-libs-browser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+      "version": "2.2.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -7679,10 +7699,10 @@
         "constants-browserify": "^1.0.0",
         "crypto-browserify": "^3.11.0",
         "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
+        "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
+        "path-browserify": "0.0.1",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -7693,8 +7713,8 @@
         "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
-        "util": "^0.10.3",
-        "vm-browserify": "0.0.4"
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "punycode": {
@@ -8041,9 +8061,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+      "version": "1.0.10",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI=",
       "dev": true
     },
     "parallel-transform": {
@@ -8067,16 +8087,17 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+      "version": "5.1.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-glob": {
@@ -8136,9 +8157,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
@@ -8201,8 +8222,8 @@
     },
     "pbkdf2": {
       "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -8459,8 +8480,8 @@
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
@@ -8547,9 +8568,9 @@
       }
     },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -8557,8 +8578,8 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
@@ -8666,8 +8687,8 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -9006,8 +9027,8 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
@@ -9099,12 +9120,13 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+      "version": "1.0.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
       }
     },
@@ -9224,9 +9246,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -9260,8 +9282,8 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -9674,9 +9696,9 @@
       "dev": true
     },
     "stream-browserify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "version": "2.0.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
         "inherits": "~2.0.1",
@@ -9695,8 +9717,8 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -9805,6 +9827,277 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
       "dev": true
+    },
+    "terser": {
+      "version": "4.6.3",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/terser/-/terser-4.6.3.tgz",
+      "integrity": "sha1-4zqkJGHO1SONNS0t8qZ/IZIfjYc=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.16",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map-support/-/source-map-support-0.5.16.tgz",
+          "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.4.3",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+          "dev": true
+        },
+        "cacache": {
+          "version": "12.0.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "2.1.2",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+          "dev": true
+        }
+      }
     },
     "test-exclude": {
       "version": "4.2.3",
@@ -9944,9 +10237,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+      "version": "2.0.11",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
@@ -10112,51 +10405,30 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+    "uglify-js": {
+      "version": "3.7.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/uglify-js/-/uglify-js-3.7.5.tgz",
+      "integrity": "sha1-J4x8JJJ6xaMtMzb8aP1K4Rd6SGo=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "commander": "~2.13.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
+          "version": "2.20.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true,
+          "optional": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-      "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-      "dev": true,
-      "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10189,38 +10461,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {
@@ -10288,9 +10537,9 @@
       }
     },
     "upath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "version": "1.2.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
       "dev": true
     },
     "upper-case": {
@@ -10349,9 +10598,9 @@
       "dev": true
     },
     "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "version": "0.11.1",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
@@ -10425,13 +10674,10 @@
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "1.1.2",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+      "dev": true
     },
     "vue": {
       "version": "1.0.27",
@@ -10479,8 +10725,8 @@
     },
     "watchpack": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.2",
@@ -10504,35 +10750,124 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.20.2.tgz",
-      "integrity": "sha512-75WFUMblcWYcocjSLlXCb71QuGyH7egdBZu50FtBGl2Nso8CK3Ej+J7bTZz2FPFq5l6fzCisD9modB7t30ikuA==",
+      "version": "4.41.5",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/webpack/-/webpack-4.41.5.tgz",
+      "integrity": "sha1-MhDxiGvOUxDmK7lyBNGMJjNBt3w=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.8",
-        "@webassemblyjs/helper-module-context": "1.7.8",
-        "@webassemblyjs/wasm-edit": "1.7.8",
-        "@webassemblyjs/wasm-parser": "1.7.8",
-        "acorn": "^5.6.2",
-        "acorn-dynamic-import": "^3.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.2.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
+        "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
-        "schema-utils": "^0.4.4",
-        "tapable": "^1.1.0",
-        "uglifyjs-webpack-plugin": "^1.2.4",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.3.0"
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.6.0",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/acorn/-/acorn-6.4.0.tgz",
+          "integrity": "sha1-tlnS/7r6JLr12xzbsslKmD7NJ4Q=",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
+          "dev": true
+        },
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
       }
     },
     "webpack-cli": {
@@ -10787,9 +11122,9 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+      "version": "1.7.0",
+      "resolved": "https://repo.mamdev.server.lan/artifactory/api/npm/npm-snapshots/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
         "errno": "~0.1.7"

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "jest": "^23.6.0",
     "mini-css-extract-plugin": "^0.4.3",
     "regenerator-runtime": "^0.12.1",
-    "webpack": "^4.20.2",
+    "webpack": "^4.41.5",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": ">=3.1.11"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.18.1",
     "date-fns": "^1.29.0",
     "vue": "^1.0.27"
   },


### PR DESCRIPTION
* `npm audit` found 792 vulnerabilities (66 low, 6 moderate,
  718 high, 2 critical)
* By running `npm audit fix`, this is reduced to 64 vulnerabilities
  (63 low, 1 moderate) in 31388 scanned packages
* Reducing further would need major updates as 64 vulnerabilities
  require semver-major dependency updates.